### PR TITLE
Feat/replace inputs with queried airports data

### DIFF
--- a/backend/src/main/java/com/rhyun/backend/airport/controller/AirportController.java
+++ b/backend/src/main/java/com/rhyun/backend/airport/controller/AirportController.java
@@ -23,4 +23,8 @@ public class AirportController {
         return airportService.getAllAirports();
     }
 
+    @GetMapping("/options-for-input")
+    public List<String> getAirportOptions() {
+        return airportService.getAirportOptions();
+    }
 }

--- a/backend/src/main/java/com/rhyun/backend/airport/controller/AirportController.java
+++ b/backend/src/main/java/com/rhyun/backend/airport/controller/AirportController.java
@@ -1,5 +1,6 @@
 package com.rhyun.backend.airport.controller;
 
+import com.rhyun.backend.airport.dto.GetAirportDto;
 import com.rhyun.backend.airport.model.Airport;
 import com.rhyun.backend.airport.service.AirportService;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -24,7 +25,7 @@ public class AirportController {
     }
 
     @GetMapping("/options-for-input")
-    public List<String> getAirportOptions() {
+    public List<GetAirportDto> getAirportOptions() {
         return airportService.getAirportOptions();
     }
 }

--- a/backend/src/main/java/com/rhyun/backend/airport/controller/AirportController.java
+++ b/backend/src/main/java/com/rhyun/backend/airport/controller/AirportController.java
@@ -1,0 +1,26 @@
+package com.rhyun.backend.airport.controller;
+
+import com.rhyun.backend.airport.model.Airport;
+import com.rhyun.backend.airport.service.AirportService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/airport")
+public class AirportController {
+
+    private final AirportService airportService;
+
+    public AirportController (AirportService airportService) {
+        this.airportService = airportService;
+    }
+
+    @GetMapping
+    public List<Airport> getAllAirports() {
+        return airportService.getAllAirports();
+    }
+
+}

--- a/backend/src/main/java/com/rhyun/backend/airport/dto/GetAirportDto.java
+++ b/backend/src/main/java/com/rhyun/backend/airport/dto/GetAirportDto.java
@@ -1,0 +1,7 @@
+package com.rhyun.backend.airport.dto;
+
+public record GetAirportDto(
+        String code,
+        String name
+) {
+}

--- a/backend/src/main/java/com/rhyun/backend/airport/model/Airport.java
+++ b/backend/src/main/java/com/rhyun/backend/airport/model/Airport.java
@@ -1,0 +1,16 @@
+package com.rhyun.backend.airport.model;
+
+import lombok.With;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@With
+@Document(collection = "airports")
+public record Airport(
+        String id,
+        String name,
+        String iataCode,
+        GeoCode geoCode,
+        AirportAddress address,
+        AirportTimeZone timeZone
+) {
+}

--- a/backend/src/main/java/com/rhyun/backend/airport/model/AirportAddress.java
+++ b/backend/src/main/java/com/rhyun/backend/airport/model/AirportAddress.java
@@ -1,0 +1,6 @@
+package com.rhyun.backend.airport.model;
+
+public record AirportAddress(
+        String countryName
+) {
+}

--- a/backend/src/main/java/com/rhyun/backend/airport/model/AirportTimeZone.java
+++ b/backend/src/main/java/com/rhyun/backend/airport/model/AirportTimeZone.java
@@ -1,0 +1,6 @@
+package com.rhyun.backend.airport.model;
+
+public record AirportTimeZone(
+    String offSet
+) {
+}

--- a/backend/src/main/java/com/rhyun/backend/airport/model/GeoCode.java
+++ b/backend/src/main/java/com/rhyun/backend/airport/model/GeoCode.java
@@ -1,0 +1,7 @@
+package com.rhyun.backend.airport.model;
+
+public record GeoCode(
+    long latitude,
+    long longitude
+) {
+}

--- a/backend/src/main/java/com/rhyun/backend/airport/repository/AirportRepository.java
+++ b/backend/src/main/java/com/rhyun/backend/airport/repository/AirportRepository.java
@@ -1,0 +1,7 @@
+package com.rhyun.backend.airport.repository;
+
+import com.rhyun.backend.airport.model.Airport;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface AirportRepository extends MongoRepository<Airport, String> {
+}

--- a/backend/src/main/java/com/rhyun/backend/airport/service/AirportService.java
+++ b/backend/src/main/java/com/rhyun/backend/airport/service/AirportService.java
@@ -1,0 +1,21 @@
+package com.rhyun.backend.airport.service;
+
+import com.rhyun.backend.airport.model.Airport;
+import com.rhyun.backend.airport.repository.AirportRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class AirportService {
+
+    private final AirportRepository airportRepository;
+
+    public AirportService(AirportRepository airportRepository) {
+        this.airportRepository = airportRepository;
+    }
+
+    public List<Airport> getAllAirports() {
+        return airportRepository.findAll();
+    }
+}

--- a/backend/src/main/java/com/rhyun/backend/airport/service/AirportService.java
+++ b/backend/src/main/java/com/rhyun/backend/airport/service/AirportService.java
@@ -4,6 +4,7 @@ import com.rhyun.backend.airport.model.Airport;
 import com.rhyun.backend.airport.repository.AirportRepository;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -17,5 +18,18 @@ public class AirportService {
 
     public List<Airport> getAllAirports() {
         return airportRepository.findAll();
+    }
+
+    public List<String> getAirportOptions() {
+        List<Airport> airports = getAllAirports();
+
+        List<String> airportOptions = new ArrayList<>();
+
+        for (Airport airport : airports) {
+            String airportOption = airport.iataCode() + " - " + airport.name() + ", " + airport.address().countryName();
+            airportOptions.add(airportOption);
+        }
+
+        return airportOptions;
     }
 }

--- a/backend/src/main/java/com/rhyun/backend/airport/service/AirportService.java
+++ b/backend/src/main/java/com/rhyun/backend/airport/service/AirportService.java
@@ -1,7 +1,9 @@
 package com.rhyun.backend.airport.service;
 
+import com.rhyun.backend.airport.dto.GetAirportDto;
 import com.rhyun.backend.airport.model.Airport;
 import com.rhyun.backend.airport.repository.AirportRepository;
+import com.rhyun.backend.utils.StringHelper;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -20,14 +22,14 @@ public class AirportService {
         return airportRepository.findAll();
     }
 
-    public List<String> getAirportOptions() {
+    public List<GetAirportDto> getAirportOptions() {
         List<Airport> airports = getAllAirports();
 
-        List<String> airportOptions = new ArrayList<>();
+        List<GetAirportDto> airportOptions = new ArrayList<>();
 
         for (Airport airport : airports) {
-            String airportOption = airport.iataCode() + " - " + airport.name() + ", " + airport.address().countryName();
-            airportOptions.add(airportOption);
+            String name = StringHelper.capitalizeFirstLetter(airport.name() + ", " + airport.address().countryName());
+            airportOptions.add(new GetAirportDto(airport.iataCode(), name));
         }
 
         return airportOptions;

--- a/backend/src/main/java/com/rhyun/backend/utils/StringHelper.java
+++ b/backend/src/main/java/com/rhyun/backend/utils/StringHelper.java
@@ -1,0 +1,24 @@
+package com.rhyun.backend.utils;
+
+public class StringHelper {
+
+    private StringHelper() {}
+
+    public static String capitalizeFirstLetter(String input) {
+        input = input.toLowerCase();
+
+        String[] words = input.split(" ");
+
+        StringBuilder result = new StringBuilder();
+
+        for (String word : words) {
+            if (!word.isEmpty()) {
+                result.append(Character.toUpperCase(word.charAt(0)))
+                        .append(word.substring(1))
+                        .append(" ");
+            }
+        }
+
+        return result.toString().trim();
+    }
+}

--- a/backend/src/test/java/com/rhyun/backend/airport/controller/AirportIntegrationTest.java
+++ b/backend/src/test/java/com/rhyun/backend/airport/controller/AirportIntegrationTest.java
@@ -1,0 +1,88 @@
+package com.rhyun.backend.airport.controller;
+
+import com.rhyun.backend.airport.model.Airport;
+import com.rhyun.backend.airport.model.AirportAddress;
+import com.rhyun.backend.airport.model.AirportTimeZone;
+import com.rhyun.backend.airport.model.GeoCode;
+import com.rhyun.backend.airport.repository.AirportRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class AirportIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private AirportRepository airportRepository;
+
+    @Test
+    void getAllAirportsTest_whenDBIsEmpty_thenReturnEmptyList() throws Exception {
+        // GIVEN
+
+        // WHEN
+        mockMvc.perform(get("/api/airport"))
+                // THEN
+                .andExpect(status().isOk())
+                .andExpect(content().json("[]"));
+    }
+
+    @Test
+    void getAllAirportsTest_whenDBHasData_thenReturnListOfAirports() throws Exception {
+        // GIVEN
+        Airport airport1 = new Airport("123", "GDANSK", "GDN", new GeoCode(54, 18),
+                new AirportAddress("POLAND"), new AirportTimeZone("+02:00"));
+        Airport airport2 = new Airport("456", "GOTEBORG", "GOT",
+                new GeoCode(57, 12), new AirportAddress("SWEDEN"), new AirportTimeZone("+02:00"));
+
+        airportRepository.save(airport1);
+        airportRepository.save(airport2);
+
+        // WHEN
+        mockMvc.perform(get("/api/airport"))
+                // THEN
+                .andExpect(status().isOk())
+                .andExpect(content().json("""
+                    [
+                        {
+                            "id": "123",
+                            "name": "GDANSK",
+                            "iataCode": "GDN",
+                            "geoCode": {
+                                "latitude": 54,
+                                "longitude": 18
+                            },
+                            "address": {
+                                "countryName": "POLAND"
+                            },
+                            "timeZone": {
+                                "offSet": "+02:00"
+                            }
+                        },
+                        {
+                            "id": "456",
+                            "name": "GOTEBORG",
+                            "iataCode": "GOT",
+                            "geoCode": {
+                                "latitude": 57,
+                                "longitude": 12
+                            },
+                            "address": {
+                                "countryName": "SWEDEN"
+                            },
+                            "timeZone": {
+                                "offSet": "+02:00"
+                            }
+                        }
+                    ]
+                """));
+    }
+}

--- a/backend/src/test/java/com/rhyun/backend/airport/service/AirportServiceTest.java
+++ b/backend/src/test/java/com/rhyun/backend/airport/service/AirportServiceTest.java
@@ -1,0 +1,56 @@
+package com.rhyun.backend.airport.service;
+
+import com.rhyun.backend.airport.model.Airport;
+import com.rhyun.backend.airport.model.AirportAddress;
+import com.rhyun.backend.airport.model.AirportTimeZone;
+import com.rhyun.backend.airport.model.GeoCode;
+import com.rhyun.backend.airport.repository.AirportRepository;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+class AirportServiceTest {
+
+    private final AirportRepository airportRepository = mock(AirportRepository.class);
+    private final AirportService airportService = new AirportService(airportRepository);
+
+    @Test
+    void getAllAirportsTest_whenDBIsEmpty_thenReturnEmptyList() {
+        // GIVEN
+        List<Airport> airports = new ArrayList<>();
+        when(airportRepository.findAll()).thenReturn(airports);
+
+        // WHEN
+        List<Airport> actual = airportService.getAllAirports();
+
+        // THEN
+        verify(airportRepository, times(1)).findAll();
+        assertThat(actual).isEmpty();
+    }
+
+    @Test
+    void getAllAirportsTest_whenDBHasData_thenReturnListOfAirports() {
+        // GIVEN
+        Airport airport1 = new Airport("123", "GDANSK", "GDN", new GeoCode(54, 18),
+                new AirportAddress("POLAND"), new AirportTimeZone("+02:00"));
+        Airport airport2 = new Airport("456", "GOTEBORG", "GOT", new GeoCode(57, 12),
+                new AirportAddress("SWEDEN"), new AirportTimeZone("+02:00"));
+
+        List<Airport> airports = List.of(airport1, airport2);
+        when(airportRepository.findAll()).thenReturn(airports);
+
+        // WHEN
+        List<Airport> actual = airportService.getAllAirports();
+
+        // THEN
+        List<Airport> expected = List.of(airport1, airport2);
+
+        assertEquals(expected, actual);
+        verify(airportRepository, times(1)).findAll();
+    }
+}

--- a/backend/src/test/java/com/rhyun/backend/airport/service/AirportServiceTest.java
+++ b/backend/src/test/java/com/rhyun/backend/airport/service/AirportServiceTest.java
@@ -1,5 +1,6 @@
 package com.rhyun.backend.airport.service;
 
+import com.rhyun.backend.airport.dto.GetAirportDto;
 import com.rhyun.backend.airport.model.Airport;
 import com.rhyun.backend.airport.model.AirportAddress;
 import com.rhyun.backend.airport.model.AirportTimeZone;
@@ -19,6 +20,11 @@ class AirportServiceTest {
     private final AirportRepository airportRepository = mock(AirportRepository.class);
     private final AirportService airportService = new AirportService(airportRepository);
 
+    Airport airport1 = new Airport("123", "GDANSK", "GDN", new GeoCode(54, 18),
+            new AirportAddress("POLAND"), new AirportTimeZone("+02:00"));
+    Airport airport2 = new Airport("456", "GOTEBORG", "GOT", new GeoCode(57, 12),
+            new AirportAddress("SWEDEN"), new AirportTimeZone("+02:00"));
+
     @Test
     void getAllAirportsTest_whenDBIsEmpty_thenReturnEmptyList() {
         // GIVEN
@@ -36,11 +42,6 @@ class AirportServiceTest {
     @Test
     void getAllAirportsTest_whenDBHasData_thenReturnListOfAirports() {
         // GIVEN
-        Airport airport1 = new Airport("123", "GDANSK", "GDN", new GeoCode(54, 18),
-                new AirportAddress("POLAND"), new AirportTimeZone("+02:00"));
-        Airport airport2 = new Airport("456", "GOTEBORG", "GOT", new GeoCode(57, 12),
-                new AirportAddress("SWEDEN"), new AirportTimeZone("+02:00"));
-
         List<Airport> airports = List.of(airport1, airport2);
         when(airportRepository.findAll()).thenReturn(airports);
 
@@ -49,6 +50,38 @@ class AirportServiceTest {
 
         // THEN
         List<Airport> expected = List.of(airport1, airport2);
+
+        assertEquals(expected, actual);
+        verify(airportRepository, times(1)).findAll();
+    }
+
+    @Test
+    void getAirportOptionsTest_whenDBIsEmpty_thenReturnEmptyList () {
+        // GIVEN
+        List<Airport> airports = new ArrayList<>();
+        when(airportRepository.findAll()).thenReturn(airports);
+
+        // WHEN
+        List<GetAirportDto> actual = airportService.getAirportOptions();
+
+        // THEN
+        assertThat(actual).isEmpty();
+        verify(airportRepository, times(1)).findAll();
+    }
+
+    @Test
+    void getAirportOptionsTest_whenDBHasData_thenReturnListOfAirports () {
+        // GIVEN
+        List<Airport> airports = List.of(airport1, airport2);
+        when(airportRepository.findAll()).thenReturn(airports);
+
+        // WHEN
+        List<GetAirportDto> actual = airportService.getAirportOptions();
+
+        // THEN
+        GetAirportDto airportDto1 = new GetAirportDto("GDN", "Gdansk, Poland");
+        GetAirportDto airportDto2 = new GetAirportDto("GOT", "Goteborg, Sweden");
+        List<GetAirportDto> expected = List.of(airportDto1, airportDto2);
 
         assertEquals(expected, actual);
         verify(airportRepository, times(1)).findAll();

--- a/backend/src/test/java/com/rhyun/backend/utils/StringHelperTest.java
+++ b/backend/src/test/java/com/rhyun/backend/utils/StringHelperTest.java
@@ -3,12 +3,13 @@ package com.rhyun.backend.utils;
 import org.junit.jupiter.api.Test;
 
 import static com.rhyun.backend.utils.StringHelper.capitalizeFirstLetter;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 class StringHelperTest {
 
     @Test
-    void capitalizeFirstLetterTest() {
+    void capitalizeFirstLetterTest_whenInputHasValue_thenReturnString() {
         // GIVEN
         String input1 = "HeLLo, wORLD!";
         String input2 = "FRIDAY";
@@ -23,5 +24,18 @@ class StringHelperTest {
         assertEquals("Hello, World!", actual1);
         assertEquals("Friday", actual2);
         assertEquals("Take A Rest..", actual3);
+    }
+
+    @Test
+    void capitalizeFirstLetterTest_whenInputIsEmpty_thenReturnNothing() {
+        // GIVEN
+        String input1 = "  ";
+
+        // WHEN
+        String actual1 = capitalizeFirstLetter(input1);
+
+        // THEN
+        assertEquals("", actual1);
+        assertThat(actual1).isEmpty();
     }
 }

--- a/backend/src/test/java/com/rhyun/backend/utils/StringHelperTest.java
+++ b/backend/src/test/java/com/rhyun/backend/utils/StringHelperTest.java
@@ -1,0 +1,27 @@
+package com.rhyun.backend.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static com.rhyun.backend.utils.StringHelper.capitalizeFirstLetter;
+import static org.junit.jupiter.api.Assertions.*;
+
+class StringHelperTest {
+
+    @Test
+    void capitalizeFirstLetterTest() {
+        // GIVEN
+        String input1 = "HeLLo, wORLD!";
+        String input2 = "FRIDAY";
+        String input3 = "take a rest..";
+
+        // WHEN
+        String actual1 = capitalizeFirstLetter(input1);
+        String actual2 = capitalizeFirstLetter(input2);
+        String actual3 = capitalizeFirstLetter(input3);
+
+        // THEN
+        assertEquals("Hello, World!", actual1);
+        assertEquals("Friday", actual2);
+        assertEquals("Take A Rest..", actual3);
+    }
+}

--- a/frontend/src/components/FlightForm/FlightForm.tsx
+++ b/frontend/src/components/FlightForm/FlightForm.tsx
@@ -11,7 +11,14 @@ import {
     TextField
 } from "@mui/material";
 import {capitalizeFirstLetter} from "../../utils/funtioncs.ts";
-import {Airline, AirlinesAsList, Airport, AirportsAsList, FlightStatus, FlightStatusList} from "../../types/enum.ts";
+import {
+    Airline,
+    AirlinesAsList,
+    Airport,
+    AirportsAsInput,
+    FlightStatus,
+    FlightStatusList
+} from "../../types/enum.ts";
 import axios from "axios";
 
 type FlightFormProps = {
@@ -23,18 +30,19 @@ type FlightFormProps = {
 }
 
 export default function FlightForm({newFlight, setNewFlight, handleSubmit, buttonLabel, editable}: Readonly<FlightFormProps>) {
-    const [airports, setAirports] = useState([]);
-console.log(airports)
+    const [airports, setAirports] = useState<AirportsAsInput[]>([{
+        code: '',
+        name: ''
+    }]);
+
     useEffect(() => {
-        axios.get("/api/airport")
+        axios.get("/api/airport/options-for-input")
             .then(response => {
                 setAirports(response.data);
-                console.log(response)
             })
             .catch(error => alert(error));
     }, [])
 
-    //console.log(airports);
     const handleChange = (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement> | ChangeEvent<HTMLSelectElement> | SelectChangeEvent<FlightStatus>) => {
         const { name, value } = event.target;
         setNewFlight({ ...newFlight, [name]: value });
@@ -49,14 +57,14 @@ console.log(airports)
 
     const handleOriginChange = (_event: SyntheticEvent<Element, Event>, value: string) => {
         if (value) {
-            const originToSave= AirportsAsList.filter(airport => value.includes(airport.code))[0].code;
+            const originToSave= airports.filter(airport => value.includes(airport.code))[0].code;
             setNewFlight({ ...newFlight, origin: originToSave as Airport });
         }
     };
 
     const handleDestinationChange = (_event: SyntheticEvent<Element, Event>, value: string) => {
         if (value) {
-            const destinationToSave= AirportsAsList.filter(airport => value.includes(airport.code))[0].code;
+            const destinationToSave= airports.filter(airport => value.includes(airport.code))[0].code;
             setNewFlight({ ...newFlight, destination: destinationToSave as Airport });
         }
     };
@@ -98,19 +106,19 @@ console.log(airports)
             />
             <Autocomplete
                 disablePortal
-                options={AirportsAsList}
+                options={airports}
                 getOptionLabel={(option) => option.code + ' - ' + capitalizeFirstLetter(option.name)}
                 sx={{margin: "auto", fontSize: "12px"}}
                 onInputChange={handleOriginChange}
                 disabled={!editable}
-                value={AirportsAsList.find(option =>  option.code === newFlight.origin) || null}
+                value={airports.find(option =>  option.code === newFlight.origin) || null}
                 renderInput={(params) =>
                     <TextField
                         required
                         {...params}
                         label={"Origin"}
                         variant={"standard"}
-                        placeholder={"SFO - San Francisco, USA"}
+                        placeholder={"BKK - Bangkok, Thailand"}
                         name={"origin"}
                     />
                 }
@@ -128,12 +136,12 @@ console.log(airports)
             </div>
             <Autocomplete
                 disablePortal
-                options={AirportsAsList}
+                options={airports}
                 getOptionLabel={(option) => option.code + ' - ' + capitalizeFirstLetter(option.name)}
                 sx={{margin: "auto", fontSize: "12px"}}
                 onInputChange={handleDestinationChange}
                 disabled={!editable}
-                value={AirportsAsList.find(option =>  option.code === newFlight.destination) || null}
+                value={airports.find(option =>  option.code === newFlight.destination) || null}
                 renderInput={(params) =>
                     <TextField
                         required

--- a/frontend/src/components/FlightForm/FlightForm.tsx
+++ b/frontend/src/components/FlightForm/FlightForm.tsx
@@ -1,6 +1,6 @@
 import './FlightForm.css'
 import {NewFlight} from "../../types/model/dataType.ts";
-import {ChangeEvent, Dispatch, FormEvent, SetStateAction, SyntheticEvent} from "react";
+import {ChangeEvent, Dispatch, FormEvent, SetStateAction, SyntheticEvent, useEffect, useState} from "react";
 import {
     Autocomplete,
     FormControl,
@@ -12,6 +12,7 @@ import {
 } from "@mui/material";
 import {capitalizeFirstLetter} from "../../utils/funtioncs.ts";
 import {Airline, AirlinesAsList, Airport, AirportsAsList, FlightStatus, FlightStatusList} from "../../types/enum.ts";
+import axios from "axios";
 
 type FlightFormProps = {
     newFlight: NewFlight,
@@ -22,7 +23,18 @@ type FlightFormProps = {
 }
 
 export default function FlightForm({newFlight, setNewFlight, handleSubmit, buttonLabel, editable}: Readonly<FlightFormProps>) {
+    const [airports, setAirports] = useState([]);
+console.log(airports)
+    useEffect(() => {
+        axios.get("/api/airport")
+            .then(response => {
+                setAirports(response.data);
+                console.log(response)
+            })
+            .catch(error => alert(error));
+    }, [])
 
+    //console.log(airports);
     const handleChange = (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement> | ChangeEvent<HTMLSelectElement> | SelectChangeEvent<FlightStatus>) => {
         const { name, value } = event.target;
         setNewFlight({ ...newFlight, [name]: value });

--- a/frontend/src/components/FlightForm/FlightForm.tsx
+++ b/frontend/src/components/FlightForm/FlightForm.tsx
@@ -14,7 +14,6 @@ import {capitalizeFirstLetter} from "../../utils/funtioncs.ts";
 import {
     Airline,
     AirlinesAsList,
-    Airport,
     AirportsAsInput,
     FlightStatus,
     FlightStatusList
@@ -58,14 +57,14 @@ export default function FlightForm({newFlight, setNewFlight, handleSubmit, butto
     const handleOriginChange = (_event: SyntheticEvent<Element, Event>, value: string) => {
         if (value) {
             const originToSave= airports.filter(airport => value.includes(airport.code))[0].code;
-            setNewFlight({ ...newFlight, origin: originToSave as Airport });
+            setNewFlight({ ...newFlight, origin: originToSave });
         }
     };
 
     const handleDestinationChange = (_event: SyntheticEvent<Element, Event>, value: string) => {
         if (value) {
             const destinationToSave= airports.filter(airport => value.includes(airport.code))[0].code;
-            setNewFlight({ ...newFlight, destination: destinationToSave as Airport });
+            setNewFlight({ ...newFlight, destination: destinationToSave });
         }
     };
 
@@ -107,7 +106,7 @@ export default function FlightForm({newFlight, setNewFlight, handleSubmit, butto
             <Autocomplete
                 disablePortal
                 options={airports}
-                getOptionLabel={(option) => option.code + ' - ' + capitalizeFirstLetter(option.name)}
+                getOptionLabel={(option) => option.code + ' - ' + option.name}
                 sx={{margin: "auto", fontSize: "12px"}}
                 onInputChange={handleOriginChange}
                 disabled={!editable}
@@ -137,7 +136,7 @@ export default function FlightForm({newFlight, setNewFlight, handleSubmit, butto
             <Autocomplete
                 disablePortal
                 options={airports}
-                getOptionLabel={(option) => option.code + ' - ' + capitalizeFirstLetter(option.name)}
+                getOptionLabel={(option) => option.code + ' - ' + option.name}
                 sx={{margin: "auto", fontSize: "12px"}}
                 onInputChange={handleDestinationChange}
                 disabled={!editable}

--- a/frontend/src/pages/FlightPage/components/FlightFilter/FlightFilter.tsx
+++ b/frontend/src/pages/FlightPage/components/FlightFilter/FlightFilter.tsx
@@ -1,7 +1,8 @@
 import './FlightFilter.css';
-import {AirlinesAsList, AirportsAsList, Filter} from "../../../../types/enum.ts";
+import {AirlinesAsList, AirportsAsInput, Filter} from "../../../../types/enum.ts";
 import {capitalizeFirstLetter} from "../../../../utils/funtioncs.ts";
 import {ChangeEvent, Dispatch, FormEvent, SetStateAction, useEffect, useState} from "react";
+import axios from "axios";
 
 type FlightFilterProps = {
     selectedFilter: Filter,
@@ -15,6 +16,19 @@ export default function FlightFilter({ selectedFilter, setSelectedFilter }: Read
         destination: undefined
     });
     const [isDisabled, setIsDisabled] = useState<boolean>(true);
+
+    const [airports, setAirports] = useState<AirportsAsInput[]>([{
+        code: '',
+        name: ''
+    }]);
+
+    useEffect(() => {
+        axios.get("/api/airport/options-for-input")
+            .then(response => {
+                setAirports(response.data);
+            })
+            .catch(error => alert(error));
+    }, [])
 
     const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
         const { name, value } = event.target;
@@ -62,9 +76,9 @@ export default function FlightFilter({ selectedFilter, setSelectedFilter }: Read
                     className={"origin-dropdown"}
                 >
                     <option>All</option>
-                    {AirportsAsList.map((airport) => (
+                    {airports.map((airport) => (
                         <option key={airport.code} value={airport.code}>
-                            {airport.code + ' - ' + capitalizeFirstLetter(airport.name)}
+                            {airport.code + ' - ' + airport.name}
                         </option>
                     ))}
                 </select>
@@ -77,9 +91,9 @@ export default function FlightFilter({ selectedFilter, setSelectedFilter }: Read
                     className={"destination-dropdown"}
                 >
                     <option>All</option>
-                    {AirportsAsList.map((airport) => (
+                    {airports.map((airport) => (
                         <option key={airport.code} value={airport.code}>
-                            {airport.code + ' - ' + capitalizeFirstLetter(airport.name)}
+                            {airport.code + ' - ' + airport.name}
                         </option>
                     ))}
                 </select>

--- a/frontend/src/types/enum.ts
+++ b/frontend/src/types/enum.ts
@@ -25,24 +25,6 @@ export const FlightStatusList : FlightStatus[] = [
     "LANDED", "CANCELLED", "DIVERTED", "ARRIVED", "UNKNOWN"
 ];
 
-export enum Airport {
-    AMS = 'Amsterdam, Netherlands',
-    FRA = 'Frankfurt, Germany',
-    HND = 'Tokyo, Japan',
-    ICN = 'Incheon, South Korea',
-    IST = 'Istanbul, Turkey',
-    SEA = 'Seattle, USA',
-    SFO = 'San Francisco, USA',
-    SIN = 'Singapore, Singapore',
-    SYD = 'Sydney, Australia',
-    TPE = 'Taipei, Taiwan',
-}
-
-export const AirportsAsList = Object.entries(Airport).map(([key, value]) => ({
-    code: key,
-    name: value
-}));
-
 export type AirportsAsInput = {
     code: string,
     name: string,

--- a/frontend/src/types/enum.ts
+++ b/frontend/src/types/enum.ts
@@ -25,7 +25,6 @@ export const FlightStatusList : FlightStatus[] = [
     "LANDED", "CANCELLED", "DIVERTED", "ARRIVED", "UNKNOWN"
 ];
 
-
 export enum Airport {
     AMS = 'Amsterdam, Netherlands',
     FRA = 'Frankfurt, Germany',
@@ -44,6 +43,10 @@ export const AirportsAsList = Object.entries(Airport).map(([key, value]) => ({
     name: value
 }));
 
+export type AirportsAsInput = {
+    code: string,
+    name: string,
+}
 
 export type Filter = {
     airline: string | undefined,


### PR DESCRIPTION
Replace options of Departure and Arrival inputs with queried data in Backend.

- Stored airports data from external api to mongodb (manually)
- Retrieve and process data in Backend and send them to Frontend
- Write unit, integration tests in Backend
- Replace input options with queried data
- Remove unused enum (Airport, AirportsAsList)