### PR TITLE
Feat/replace airline inputs with queried data

### DIFF
--- a/backend/src/main/java/com/rhyun/backend/airline/controller/AirlineController.java
+++ b/backend/src/main/java/com/rhyun/backend/airline/controller/AirlineController.java
@@ -1,5 +1,6 @@
 package com.rhyun.backend.airline.controller;
 
+import com.rhyun.backend.airline.dto.GetAirlineDto;
 import com.rhyun.backend.airline.model.Airline;
 import com.rhyun.backend.airline.service.AirlineService;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -23,4 +24,8 @@ public class AirlineController {
         return airlineService.getAllAirlines();
     }
 
+    @GetMapping("/options-for-input")
+    public List<GetAirlineDto> getAirlineOptions() {
+        return airlineService.getAirlineOptions();
+    }
 }

--- a/backend/src/main/java/com/rhyun/backend/airline/controller/AirlineController.java
+++ b/backend/src/main/java/com/rhyun/backend/airline/controller/AirlineController.java
@@ -1,0 +1,26 @@
+package com.rhyun.backend.airline.controller;
+
+import com.rhyun.backend.airline.model.Airline;
+import com.rhyun.backend.airline.service.AirlineService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/airline")
+public class AirlineController {
+
+    private final AirlineService airlineService;
+
+    public AirlineController(AirlineService airlineService) {
+        this.airlineService = airlineService;
+    }
+
+    @GetMapping()
+    public List<Airline> getAllAirlines() {
+        return airlineService.getAllAirlines();
+    }
+
+}

--- a/backend/src/main/java/com/rhyun/backend/airline/dto/GetAirlineDto.java
+++ b/backend/src/main/java/com/rhyun/backend/airline/dto/GetAirlineDto.java
@@ -1,0 +1,7 @@
+package com.rhyun.backend.airline.dto;
+
+public record GetAirlineDto(
+    String code,
+    String name
+) {
+}

--- a/backend/src/main/java/com/rhyun/backend/airline/model/Airline.java
+++ b/backend/src/main/java/com/rhyun/backend/airline/model/Airline.java
@@ -1,0 +1,14 @@
+package com.rhyun.backend.airline.model;
+
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document(collection = "airlines")
+public record Airline(
+    String id,
+    String type,
+    String iataCode,
+    String icaoCode,
+    String businessName,
+    String commonName
+) {
+}

--- a/backend/src/main/java/com/rhyun/backend/airline/repository/AirlineRepository.java
+++ b/backend/src/main/java/com/rhyun/backend/airline/repository/AirlineRepository.java
@@ -1,0 +1,9 @@
+package com.rhyun.backend.airline.repository;
+
+import com.rhyun.backend.airline.model.Airline;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AirlineRepository extends MongoRepository<Airline, String> {
+}

--- a/backend/src/main/java/com/rhyun/backend/airline/service/AirlineService.java
+++ b/backend/src/main/java/com/rhyun/backend/airline/service/AirlineService.java
@@ -1,9 +1,12 @@
 package com.rhyun.backend.airline.service;
 
+import com.rhyun.backend.airline.dto.GetAirlineDto;
 import com.rhyun.backend.airline.model.Airline;
 import com.rhyun.backend.airline.repository.AirlineRepository;
+import com.rhyun.backend.utils.StringHelper;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -17,6 +20,19 @@ public class AirlineService {
 
     public List<Airline> getAllAirlines() {
         return airlineRepository.findAll();
+    }
+
+    public List<GetAirlineDto> getAirlineOptions() {
+        List<Airline> airlines = getAllAirlines();
+
+        List<GetAirlineDto> airlineOptions = new ArrayList<>();
+
+        for (Airline airline : airlines) {
+            String name = StringHelper.capitalizeFirstLetter(airline.businessName());
+            airlineOptions.add(new GetAirlineDto(airline.iataCode(), name));
+        }
+
+        return airlineOptions;
     }
 
 }

--- a/backend/src/main/java/com/rhyun/backend/airline/service/AirlineService.java
+++ b/backend/src/main/java/com/rhyun/backend/airline/service/AirlineService.java
@@ -1,0 +1,22 @@
+package com.rhyun.backend.airline.service;
+
+import com.rhyun.backend.airline.model.Airline;
+import com.rhyun.backend.airline.repository.AirlineRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class AirlineService {
+
+    private final AirlineRepository airlineRepository;
+
+    public AirlineService(AirlineRepository airlineRepository) {
+        this.airlineRepository = airlineRepository;
+    }
+
+    public List<Airline> getAllAirlines() {
+        return airlineRepository.findAll();
+    }
+
+}

--- a/backend/src/test/java/com/rhyun/backend/airline/controller/AirlineIntegrationTest.java
+++ b/backend/src/test/java/com/rhyun/backend/airline/controller/AirlineIntegrationTest.java
@@ -67,4 +67,40 @@ class AirlineIntegrationTest {
                     }]
                 """));
     }
+
+    @Test
+    @DirtiesContext
+    void getAirlineOptionsTest_whenDBIsEmpty_thenReturnEmptyList() throws Exception {
+        // GIVEN
+        // WHEN
+        mockMvc.perform(get("/api/airline/options-for-input"))
+            // THEN
+            .andExpect(status().isOk())
+            .andExpect(content().json("[]"));
+    }
+
+    @Test
+    @DirtiesContext
+    void getAirlineOptionsTest_whenDBHasData_thenReturnListOfAirlines() throws Exception {
+        // GIVEN
+        airlineRepository.save(airline1);
+        airlineRepository.save(airline2);
+
+        // WHEN
+        mockMvc.perform(get("/api/airline/options-for-input"))
+            // THEN
+            .andExpect(status().isOk())
+            .andExpect(content().json("""
+                [
+                    {
+                        "code": "SQ",
+                        "name": "Singapore Airlines"
+                    },
+                    {
+                        "code": "KE",
+                        "name": "Korean Air"
+                    }
+                ]
+            """));
+    }
 }

--- a/backend/src/test/java/com/rhyun/backend/airline/controller/AirlineIntegrationTest.java
+++ b/backend/src/test/java/com/rhyun/backend/airline/controller/AirlineIntegrationTest.java
@@ -1,0 +1,70 @@
+package com.rhyun.backend.airline.controller;
+
+import com.rhyun.backend.airline.model.Airline;
+import com.rhyun.backend.airline.repository.AirlineRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class AirlineIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private AirlineRepository airlineRepository;
+
+    Airline airline1 = new Airline("1", "airline", "SQ", "SIA",
+            "SINGAPORE AIRLINES", "SINGAPORE");
+    Airline airline2 = new Airline("2", "airline", "KE", "KAL",
+            "KOREAN AIR", "KOREAN AIR");
+
+    @Test
+    @DirtiesContext
+    void getAllAirlinesTest_whenDBIsEmpty_thenReturnEmptyList() throws Exception {
+        // GIVEN
+        // WHEN
+        mockMvc.perform(get("/api/airline"))
+            // THEN
+            .andExpect(status().isOk())
+            .andExpect(content().json("[]"));
+    }
+
+    @Test
+    @DirtiesContext
+    void getAllAirlinesTest_whenDBHasData_thenReturnListOfAirlines() throws Exception {
+        // GIVEN
+        airlineRepository.save(airline1);
+        airlineRepository.save(airline2);
+
+        // WHEN
+        mockMvc.perform(get("/api/airline"))
+            .andExpect(status().isOk())
+            .andExpect(content().json("""
+                    [{
+                        "id": "1",
+                        "type": "airline",
+                        "iataCode": "SQ",
+                        "icaoCode": "SIA",
+                        "businessName": "SINGAPORE AIRLINES",
+                        "commonName": "SINGAPORE"
+                    },
+                    {
+                        "id": "2",
+                        "type": "airline",
+                        "iataCode": "KE",
+                        "icaoCode": "KAL",
+                        "businessName": "KOREAN AIR",
+                        "commonName": "KOREAN AIR"
+                    }]
+                """));
+    }
+}

--- a/backend/src/test/java/com/rhyun/backend/airline/service/AirlineServiceTest.java
+++ b/backend/src/test/java/com/rhyun/backend/airline/service/AirlineServiceTest.java
@@ -1,5 +1,6 @@
 package com.rhyun.backend.airline.service;
 
+import com.rhyun.backend.airline.dto.GetAirlineDto;
 import com.rhyun.backend.airline.model.Airline;
 import com.rhyun.backend.airline.repository.AirlineRepository;
 import org.junit.jupiter.api.Test;
@@ -46,6 +47,38 @@ class AirlineServiceTest {
 
         // THEN
         List<Airline> expected = List.of(airline1, airline2);
+        assertEquals(expected, actual);
+        verify(airlineRepository, times(1)).findAll();
+    }
+
+    @Test
+    void getAirlineOptionsTest_whenDBIsEmpty_thenReturnEmptyList() {
+        // GIVEN
+        List<Airline> airlines = new ArrayList<>();
+        when(airlineRepository.findAll()).thenReturn(airlines);
+
+        // WHEN
+        List<GetAirlineDto> actual = airlineService.getAirlineOptions();
+
+        // THEN
+        assertThat(actual).isEmpty();
+        verify(airlineRepository, times(1)).findAll();
+    }
+
+    @Test
+    void getAirlineOptionsTest_whenDBHasData_thenReturnListOfAirlines() {
+        // GIVEN
+        List<Airline> airlines = List.of(airline1, airline2);
+        when(airlineRepository.findAll()).thenReturn(airlines);
+
+        // WHEN
+        List<GetAirlineDto> actual = airlineService.getAirlineOptions();
+
+        // THEN
+        GetAirlineDto airlineDto1 = new GetAirlineDto("SQ", "Singapore Airlines");
+        GetAirlineDto airlineDto2 = new GetAirlineDto("KE", "Korean Air");
+        List<GetAirlineDto> expected = List.of(airlineDto1, airlineDto2);
+
         assertEquals(expected, actual);
         verify(airlineRepository, times(1)).findAll();
     }

--- a/backend/src/test/java/com/rhyun/backend/airline/service/AirlineServiceTest.java
+++ b/backend/src/test/java/com/rhyun/backend/airline/service/AirlineServiceTest.java
@@ -1,0 +1,52 @@
+package com.rhyun.backend.airline.service;
+
+import com.rhyun.backend.airline.model.Airline;
+import com.rhyun.backend.airline.repository.AirlineRepository;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+class AirlineServiceTest {
+
+    private final AirlineRepository airlineRepository = mock(AirlineRepository.class);
+    private final AirlineService airlineService = new AirlineService(airlineRepository);
+
+    Airline airline1 = new Airline("1", "airline", "SQ", "SIA",
+            "SINGAPORE AIRLINES", "SINGAPORE");
+    Airline airline2 = new Airline("2", "airline", "KE", "KAL",
+            "KOREAN AIR", "KOREAN AIR");
+
+    @Test
+    void getAllAirlinesTest_whenDBIsEmpty_thenReturnEmptyList() {
+        // GIVEN
+        List<Airline> airlines = new ArrayList<>();
+        when(airlineRepository.findAll()).thenReturn(airlines);
+
+        // WHEN
+        List<Airline> actual = airlineService.getAllAirlines();
+
+        // THEN
+        assertThat(actual).isEmpty();
+        verify(airlineRepository, times(1)).findAll();
+    }
+
+    @Test
+    void getAllAirlinesTest_whenDBHasData_thenReturnListOfAirlines() {
+        // GIVEN
+        List<Airline> airlines = List.of(airline1, airline2);
+        when(airlineRepository.findAll()).thenReturn(airlines);
+
+        // WHEN
+        List<Airline> actual = airlineService.getAllAirlines();
+
+        // THEN
+        List<Airline> expected = List.of(airline1, airline2);
+        assertEquals(expected, actual);
+        verify(airlineRepository, times(1)).findAll();
+    }
+}

--- a/frontend/src/components/FlightForm/FlightForm.tsx
+++ b/frontend/src/components/FlightForm/FlightForm.tsx
@@ -1,6 +1,6 @@
 import './FlightForm.css'
 import {NewFlight} from "../../types/model/dataType.ts";
-import {ChangeEvent, Dispatch, FormEvent, SetStateAction, SyntheticEvent, useEffect, useState} from "react";
+import {ChangeEvent, Dispatch, FormEvent, SetStateAction, SyntheticEvent} from "react";
 import {
     Autocomplete,
     FormControl,
@@ -12,12 +12,10 @@ import {
 } from "@mui/material";
 import {capitalizeFirstLetter} from "../../utils/funtioncs.ts";
 import {
-    AirlineAsInput,
-    AirportsAsInput,
     FlightStatus,
     FlightStatusList
 } from "../../types/enum.ts";
-import axios from "axios";
+import {useFetchOptions} from "../../hooks/useFetchOptions.ts";
 
 type FlightFormProps = {
     newFlight: NewFlight,
@@ -28,29 +26,7 @@ type FlightFormProps = {
 }
 
 export default function FlightForm({newFlight, setNewFlight, handleSubmit, buttonLabel, editable}: Readonly<FlightFormProps>) {
-    const [airports, setAirports] = useState<AirportsAsInput[]>([{
-        code: '',
-        name: ''
-    }]);
-
-    const [airlines, setAirlines] = useState<AirlineAsInput[]>([{
-        code: '',
-        name: ''
-    }]);
-
-    useEffect(() => {
-        axios.get("/api/airport/options-for-input")
-            .then(response => {
-                setAirports(response.data);
-            })
-            .catch(error => alert(error));
-
-        axios.get("/api/airline/options-for-input")
-            .then(response => {
-                setAirlines(response.data);
-            })
-            .catch(error => alert(error));
-    }, [])
+    const { airports, airlines } = useFetchOptions();
 
     const handleChange = (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement> | ChangeEvent<HTMLSelectElement> | SelectChangeEvent<FlightStatus>) => {
         const { name, value } = event.target;

--- a/frontend/src/components/FlightForm/FlightForm.tsx
+++ b/frontend/src/components/FlightForm/FlightForm.tsx
@@ -12,8 +12,7 @@ import {
 } from "@mui/material";
 import {capitalizeFirstLetter} from "../../utils/funtioncs.ts";
 import {
-    Airline,
-    AirlinesAsList,
+    AirlineAsInput,
     AirportsAsInput,
     FlightStatus,
     FlightStatusList
@@ -34,10 +33,21 @@ export default function FlightForm({newFlight, setNewFlight, handleSubmit, butto
         name: ''
     }]);
 
+    const [airlines, setAirlines] = useState<AirlineAsInput[]>([{
+        code: '',
+        name: ''
+    }]);
+
     useEffect(() => {
         axios.get("/api/airport/options-for-input")
             .then(response => {
                 setAirports(response.data);
+            })
+            .catch(error => alert(error));
+
+        axios.get("/api/airline/options-for-input")
+            .then(response => {
+                setAirlines(response.data);
             })
             .catch(error => alert(error));
     }, [])
@@ -49,8 +59,8 @@ export default function FlightForm({newFlight, setNewFlight, handleSubmit, butto
 
     const handleAirlineChange = (_event: SyntheticEvent<Element, Event>, value: string) => {
         if (value) {
-            const airlineToSave= AirlinesAsList.filter(airline => value.includes(airline.code))[0].code;
-            setNewFlight({ ...newFlight, airline: airlineToSave as Airline });
+            const airlineToSave= airlines.filter(airline => value.includes(airline.code))[0].code;
+            setNewFlight({ ...newFlight, airline: airlineToSave });
         }
     };
 
@@ -72,12 +82,12 @@ export default function FlightForm({newFlight, setNewFlight, handleSubmit, butto
         <form className={"add-flight-form"} onSubmit={handleSubmit}>
             <Autocomplete
                 disablePortal
-                options={AirlinesAsList}
+                options={airlines}
                 getOptionLabel={(option) => option.code + ' - ' + capitalizeFirstLetter(option.name)}
                 sx={{margin: "auto", fontSize: "12px"}}
                 onInputChange={handleAirlineChange}
                 disabled={!editable}
-                value={AirlinesAsList.find(option => option.code === newFlight.airline) || null}
+                value={airlines.find(option => option.code === newFlight.airline) || null}
                 renderInput={(params) =>
                     <TextField
                         required

--- a/frontend/src/hooks/useFetchOptions.ts
+++ b/frontend/src/hooks/useFetchOptions.ts
@@ -1,10 +1,10 @@
 import {useEffect, useState} from "react";
-import {AirlineAsInput, AirportsAsInput} from "../types/enum.ts";
+import {AirlinesAsInput, AirportsAsInput} from "../types/enum.ts";
 import axios from "axios";
 
 export const useFetchOptions = () => {
     const [airports, setAirports] = useState<AirportsAsInput[]>([]);
-    const [airlines, setAirlines] = useState<AirlineAsInput[]>([]);
+    const [airlines, setAirlines] = useState<AirlinesAsInput[]>([]);
     const [error, setError] = useState<string | null>(null);
     const [loading, setLoading] = useState<boolean>(true);
 
@@ -13,7 +13,7 @@ export const useFetchOptions = () => {
             try {
                 const [airportsResponse, airlinesResponse] = await Promise.all([
                     axios.get<AirportsAsInput[]>("/api/airport/options-for-input"),
-                    axios.get<AirlineAsInput[]>("/api/airline/options-for-input")
+                    axios.get<AirlinesAsInput[]>("/api/airline/options-for-input")
                 ]);
 
                 setAirports(airportsResponse.data);

--- a/frontend/src/hooks/useFetchOptions.ts
+++ b/frontend/src/hooks/useFetchOptions.ts
@@ -1,0 +1,32 @@
+import {useEffect, useState} from "react";
+import {AirlineAsInput, AirportsAsInput} from "../types/enum.ts";
+import axios from "axios";
+
+export const useFetchOptions = () => {
+    const [airports, setAirports] = useState<AirportsAsInput[]>([]);
+    const [airlines, setAirlines] = useState<AirlineAsInput[]>([]);
+    const [error, setError] = useState<string | null>(null);
+    const [loading, setLoading] = useState<boolean>(true);
+
+    useEffect(() => {
+        const fetchData = async () => {
+            try {
+                const [airportsResponse, airlinesResponse] = await Promise.all([
+                    axios.get<AirportsAsInput[]>("/api/airport/options-for-input"),
+                    axios.get<AirlineAsInput[]>("/api/airline/options-for-input")
+                ]);
+
+                setAirports(airportsResponse.data);
+                setAirlines(airlinesResponse.data);
+            } catch {
+                setError('An error occurred');
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        fetchData();
+    }, []);
+
+    return { airports, airlines, loading, error };
+};

--- a/frontend/src/pages/FlightPage/components/FlightFilter/FlightFilter.tsx
+++ b/frontend/src/pages/FlightPage/components/FlightFilter/FlightFilter.tsx
@@ -1,8 +1,8 @@
 import './FlightFilter.css';
-import {AirlinesAsList, AirportsAsInput, Filter} from "../../../../types/enum.ts";
+import {Filter} from "../../../../types/enum.ts";
 import {capitalizeFirstLetter} from "../../../../utils/funtioncs.ts";
 import {ChangeEvent, Dispatch, FormEvent, SetStateAction, useEffect, useState} from "react";
-import axios from "axios";
+import {useFetchOptions} from "../../../../hooks/useFetchOptions.ts";
 
 type FlightFilterProps = {
     selectedFilter: Filter,
@@ -10,25 +10,13 @@ type FlightFilterProps = {
 }
 
 export default function FlightFilter({ selectedFilter, setSelectedFilter }: Readonly<FlightFilterProps>) {
+    const { airports, airlines } = useFetchOptions();
     const [filter, setFilter] = useState<Filter>({
         airline: undefined,
         origin: undefined,
         destination: undefined
     });
     const [isDisabled, setIsDisabled] = useState<boolean>(true);
-
-    const [airports, setAirports] = useState<AirportsAsInput[]>([{
-        code: '',
-        name: ''
-    }]);
-
-    useEffect(() => {
-        axios.get("/api/airport/options-for-input")
-            .then(response => {
-                setAirports(response.data);
-            })
-            .catch(error => alert(error));
-    }, [])
 
     const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
         const { name, value } = event.target;
@@ -61,7 +49,7 @@ export default function FlightFilter({ selectedFilter, setSelectedFilter }: Read
                     className={"airline-dropdown"}
                 >
                     <option>All</option>
-                    {AirlinesAsList.map((airline) => (
+                    {airlines.map((airline) => (
                         <option key={airline.code} value={airline.code}>
                             {airline.code + ' - ' + capitalizeFirstLetter(airline.name)}
                         </option>

--- a/frontend/src/pages/FlightPage/components/FlightList/FlightList.tsx
+++ b/frontend/src/pages/FlightPage/components/FlightList/FlightList.tsx
@@ -1,8 +1,6 @@
 import './FlightList.css'
 import {Flight} from "../../../../types/model/dataType.ts";
-import {Airline} from "../../../../types/enum.ts";
 import FlightTakeoffIcon from '@mui/icons-material/FlightTakeoff';
-import {capitalizeFirstLetter} from "../../../../utils/funtioncs.ts";
 import {calculateDuration, formatDate, formatTime} from "../../../../utils/functionsForTime.ts";
 import {Link, useNavigate} from "react-router-dom";
 import axios from "axios";
@@ -10,6 +8,7 @@ import ConfirmationModal from "../../../../components/ConfirmationModal/Confirma
 import {useEffect, useState} from "react";
 import DeleteIcon from '@mui/icons-material/Delete';
 import Notification from "../../../../components/Notification/Notification.tsx";
+import {useFetchOptions} from "../../../../hooks/useFetchOptions.ts";
 
 type FlightListProps = {
     data: Flight[],
@@ -20,6 +19,7 @@ export default function FlightList({ data, fetchAllFlights }: Readonly<FlightLis
     const [showDeleteModal, setShowDeleteModal] = useState<boolean>(false);
     const [flightToDelete, setFlightToDelete] = useState<Flight | null>(null);
     const [showNotification, setShowNotification] = useState<boolean>(false);
+    const { airlines } = useFetchOptions();
 
     const navigate = useNavigate();
 
@@ -65,8 +65,13 @@ export default function FlightList({ data, fetchAllFlights }: Readonly<FlightLis
                 <div key={flight.id} className={"flight-card"}>
                     <div className={"flight-card-headline"}>
                         <div className={"flight-card-airline"}>
-                            <FlightTakeoffIcon sx={{ fontSize: "25px"}}/>
-                            <h4>{capitalizeFirstLetter(Airline[flight.airline as unknown as keyof typeof Airline])}</h4>
+                            <FlightTakeoffIcon sx={{fontSize: "25px"}}/>
+                            <h4>
+                                {airlines
+                                    .filter(airline => airline.code.toLowerCase() === flight.airline.toLowerCase())
+                                    .map(filteredAirline => filteredAirline.name)
+                                }
+                            </h4>
                             <h4>{flight.flightCode}</h4>
                         </div>
                         <div className={"flight-card-icons"}>

--- a/frontend/src/types/enum.ts
+++ b/frontend/src/types/enum.ts
@@ -1,17 +1,3 @@
-export enum Airline {
-    UNKNOWN = 'Unknown',
-    CI = 'CHINA AIR',
-    DL = 'DELTA AIR LINES',
-    KE = 'KOREAN AIR',
-    KL = 'KLM ROYAL DUTCH AIRLINES',
-    LH = 'LUFTHANSA',
-    NH = 'ALL NIPPON AIRWAYS',
-    NQ = 'AIR JAPAN COMPANY LTD',
-    QF = 'QANTAS AIRWAYS',
-    SQ = 'SINGAPORE AIRLINES',
-    TK = 'TURKISH AIRLINES'
-}
-
 export type FlightStatus = "SCHEDULED" | "BOARDING" | "DELAYED" | "IN_AIR" |
     "LANDED"| "CANCELLED" | "DIVERTED" | "ARRIVED" | "UNKNOWN";
 

--- a/frontend/src/types/enum.ts
+++ b/frontend/src/types/enum.ts
@@ -30,6 +30,11 @@ export type AirportsAsInput = {
     name: string,
 }
 
+export type AirlineAsInput = {
+    code: string,
+    name: string,
+}
+
 export type Filter = {
     airline: string | undefined,
     origin: string | undefined,

--- a/frontend/src/types/enum.ts
+++ b/frontend/src/types/enum.ts
@@ -12,11 +12,6 @@ export enum Airline {
     TK = 'TURKISH AIRLINES'
 }
 
-export const AirlinesAsList = Object.entries(Airline).map(([key, value]) => ({
-    code: key,
-    name: value
-}));
-
 export type FlightStatus = "SCHEDULED" | "BOARDING" | "DELAYED" | "IN_AIR" |
     "LANDED"| "CANCELLED" | "DIVERTED" | "ARRIVED" | "UNKNOWN";
 
@@ -30,7 +25,7 @@ export type AirportsAsInput = {
     name: string,
 }
 
-export type AirlineAsInput = {
+export type AirlinesAsInput = {
     code: string,
     name: string,
 }

--- a/frontend/src/types/model/dataType.ts
+++ b/frontend/src/types/model/dataType.ts
@@ -1,9 +1,9 @@
-import {Airline, FlightStatus} from "../enum.ts";
+import {FlightStatus} from "../enum.ts";
 
 export type Flight = {
     id: string,
     flightCode: string,
-    airline: Airline,
+    airline: string,
     origin: string,
     destination: string,
     departureTime: string,


### PR DESCRIPTION
Airline inputs and filter can have values from MongoDB.
- Create an Airline Entity, Controller, Service Repository
- Create an endpoint to send processed data to the frontend
- Replace inputs and filter values with queried data
- Remove unused enum and datatype in Frontend