### PR TITLE
Feat/extend airport endpoints

### DIFF
--- a/backend/src/main/java/com/rhyun/backend/airport/controller/AirportController.java
+++ b/backend/src/main/java/com/rhyun/backend/airport/controller/AirportController.java
@@ -3,10 +3,7 @@ package com.rhyun.backend.airport.controller;
 import com.rhyun.backend.airport.dto.GetAirportDto;
 import com.rhyun.backend.airport.model.Airport;
 import com.rhyun.backend.airport.service.AirportService;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -33,5 +30,10 @@ public class AirportController {
     @GetMapping("/{id}")
     public Airport getAirportById(@PathVariable String id) {
         return airportService.getAirportById(id);
+    }
+
+    @DeleteMapping("/{id}")
+    public void deleteAirportById(@PathVariable String id) {
+        airportService.deleteAirportById(id);
     }
 }

--- a/backend/src/main/java/com/rhyun/backend/airport/controller/AirportController.java
+++ b/backend/src/main/java/com/rhyun/backend/airport/controller/AirportController.java
@@ -1,5 +1,6 @@
 package com.rhyun.backend.airport.controller;
 
+import com.rhyun.backend.airport.dto.AirportDto;
 import com.rhyun.backend.airport.dto.GetAirportDto;
 import com.rhyun.backend.airport.model.Airport;
 import com.rhyun.backend.airport.service.AirportService;
@@ -35,5 +36,10 @@ public class AirportController {
     @DeleteMapping("/{id}")
     public void deleteAirportById(@PathVariable String id) {
         airportService.deleteAirportById(id);
+    }
+
+    @PostMapping
+    public Airport createAirport(@RequestBody AirportDto airportDto) {
+        return airportService.createAirport(airportDto);
     }
 }

--- a/backend/src/main/java/com/rhyun/backend/airport/controller/AirportController.java
+++ b/backend/src/main/java/com/rhyun/backend/airport/controller/AirportController.java
@@ -3,6 +3,7 @@ package com.rhyun.backend.airport.controller;
 import com.rhyun.backend.airport.dto.AirportDto;
 import com.rhyun.backend.airport.dto.GetAirportDto;
 import com.rhyun.backend.airport.model.Airport;
+import com.rhyun.backend.airport.repository.AirportRepository;
 import com.rhyun.backend.airport.service.AirportService;
 import org.springframework.web.bind.annotation.*;
 
@@ -13,9 +14,11 @@ import java.util.List;
 public class AirportController {
 
     private final AirportService airportService;
+    private final AirportRepository airportRepository;
 
-    public AirportController (AirportService airportService) {
+    public AirportController (AirportService airportService, AirportRepository airportRepository) {
         this.airportService = airportService;
+        this.airportRepository = airportRepository;
     }
 
     @GetMapping
@@ -41,5 +44,10 @@ public class AirportController {
     @PostMapping
     public Airport createAirport(@RequestBody AirportDto airportDto) {
         return airportService.createAirport(airportDto);
+    }
+
+    @PutMapping("/{id}")
+    public Airport updateAirport(@PathVariable String id, @RequestBody AirportDto airportDto) {
+        return airportService.updateAirport(id, airportDto);
     }
 }

--- a/backend/src/main/java/com/rhyun/backend/airport/controller/AirportController.java
+++ b/backend/src/main/java/com/rhyun/backend/airport/controller/AirportController.java
@@ -3,7 +3,6 @@ package com.rhyun.backend.airport.controller;
 import com.rhyun.backend.airport.dto.AirportDto;
 import com.rhyun.backend.airport.dto.GetAirportDto;
 import com.rhyun.backend.airport.model.Airport;
-import com.rhyun.backend.airport.repository.AirportRepository;
 import com.rhyun.backend.airport.service.AirportService;
 import org.springframework.web.bind.annotation.*;
 
@@ -14,11 +13,9 @@ import java.util.List;
 public class AirportController {
 
     private final AirportService airportService;
-    private final AirportRepository airportRepository;
 
-    public AirportController (AirportService airportService, AirportRepository airportRepository) {
+    public AirportController (AirportService airportService) {
         this.airportService = airportService;
-        this.airportRepository = airportRepository;
     }
 
     @GetMapping

--- a/backend/src/main/java/com/rhyun/backend/airport/controller/AirportController.java
+++ b/backend/src/main/java/com/rhyun/backend/airport/controller/AirportController.java
@@ -4,6 +4,7 @@ import com.rhyun.backend.airport.dto.GetAirportDto;
 import com.rhyun.backend.airport.model.Airport;
 import com.rhyun.backend.airport.service.AirportService;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -27,5 +28,10 @@ public class AirportController {
     @GetMapping("/options-for-input")
     public List<GetAirportDto> getAirportOptions() {
         return airportService.getAirportOptions();
+    }
+
+    @GetMapping("/{id}")
+    public Airport getAirportById(@PathVariable String id) {
+        return airportService.getAirportById(id);
     }
 }

--- a/backend/src/main/java/com/rhyun/backend/airport/dto/AirportDto.java
+++ b/backend/src/main/java/com/rhyun/backend/airport/dto/AirportDto.java
@@ -1,0 +1,14 @@
+package com.rhyun.backend.airport.dto;
+
+import com.rhyun.backend.airport.model.AirportAddress;
+import com.rhyun.backend.airport.model.AirportTimeZone;
+import com.rhyun.backend.airport.model.GeoCode;
+
+public record AirportDto(
+    String name,
+    String iataCode,
+    GeoCode geoCode,
+    AirportAddress address,
+    AirportTimeZone timeZone
+) {
+}

--- a/backend/src/main/java/com/rhyun/backend/airport/exception/AirportNotFoundException.java
+++ b/backend/src/main/java/com/rhyun/backend/airport/exception/AirportNotFoundException.java
@@ -1,0 +1,7 @@
+package com.rhyun.backend.airport.exception;
+
+public class AirportNotFoundException extends RuntimeException{
+    public AirportNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/rhyun/backend/airport/service/AirportService.java
+++ b/backend/src/main/java/com/rhyun/backend/airport/service/AirportService.java
@@ -40,4 +40,9 @@ public class AirportService {
         return airportRepository.findById(id)
                 .orElseThrow(() -> new AirportNotFoundException("The Airport with id " + id + " cannot be found."));
     }
+
+    public void deleteAirportById(String id) {
+        airportRepository.deleteById(id);
+        System.out.println("The Airport with id "+ id + " has been deleted.");
+    }
 }

--- a/backend/src/main/java/com/rhyun/backend/airport/service/AirportService.java
+++ b/backend/src/main/java/com/rhyun/backend/airport/service/AirportService.java
@@ -1,6 +1,7 @@
 package com.rhyun.backend.airport.service;
 
 import com.rhyun.backend.airport.dto.GetAirportDto;
+import com.rhyun.backend.airport.exception.AirportNotFoundException;
 import com.rhyun.backend.airport.model.Airport;
 import com.rhyun.backend.airport.repository.AirportRepository;
 import com.rhyun.backend.utils.StringHelper;
@@ -33,5 +34,10 @@ public class AirportService {
         }
 
         return airportOptions;
+    }
+
+    public Airport getAirportById(String id) {
+        return airportRepository.findById(id)
+                .orElseThrow(() -> new AirportNotFoundException("The Airport with id " + id + " cannot be found."));
     }
 }

--- a/backend/src/main/java/com/rhyun/backend/airport/service/AirportService.java
+++ b/backend/src/main/java/com/rhyun/backend/airport/service/AirportService.java
@@ -1,9 +1,11 @@
 package com.rhyun.backend.airport.service;
 
+import com.rhyun.backend.airport.dto.AirportDto;
 import com.rhyun.backend.airport.dto.GetAirportDto;
 import com.rhyun.backend.airport.exception.AirportNotFoundException;
 import com.rhyun.backend.airport.model.Airport;
 import com.rhyun.backend.airport.repository.AirportRepository;
+import com.rhyun.backend.globalservice.IdService;
 import com.rhyun.backend.utils.StringHelper;
 import org.springframework.stereotype.Service;
 
@@ -14,9 +16,11 @@ import java.util.List;
 public class AirportService {
 
     private final AirportRepository airportRepository;
+    private final IdService idService;
 
-    public AirportService(AirportRepository airportRepository) {
+    public AirportService(AirportRepository airportRepository, IdService idService) {
         this.airportRepository = airportRepository;
+        this.idService = idService;
     }
 
     public List<Airport> getAllAirports() {
@@ -44,5 +48,17 @@ public class AirportService {
     public void deleteAirportById(String id) {
         airportRepository.deleteById(id);
         System.out.println("The Airport with id "+ id + " has been deleted.");
+    }
+    
+    public Airport createAirport(AirportDto airportDto) {
+        Airport airportToSave = new Airport(
+                idService.randomId(),
+                airportDto.name(),
+                airportDto.iataCode(),
+                airportDto.geoCode(),
+                airportDto.address(),
+                airportDto.timeZone()
+        );
+        return airportRepository.save(airportToSave);
     }
 }

--- a/backend/src/main/java/com/rhyun/backend/airport/service/AirportService.java
+++ b/backend/src/main/java/com/rhyun/backend/airport/service/AirportService.java
@@ -61,4 +61,16 @@ public class AirportService {
         );
         return airportRepository.save(airportToSave);
     }
+
+    public Airport updateAirport(String id, AirportDto airportDto) {
+        Airport airportToUpdate = airportRepository.findById(id)
+                .orElseThrow()
+                .withName(airportDto.name())
+                .withIataCode(airportDto.iataCode())
+                .withGeoCode(airportDto.geoCode())
+                .withAddress(airportDto.address())
+                .withTimeZone(airportDto.timeZone());
+
+        return airportRepository.save(airportToUpdate);
+    }
 }

--- a/backend/src/main/java/com/rhyun/backend/airport/service/AirportService.java
+++ b/backend/src/main/java/com/rhyun/backend/airport/service/AirportService.java
@@ -48,7 +48,6 @@ public class AirportService {
 
     public void deleteAirportById(String id) {
         airportRepository.deleteById(id);
-        System.out.println(airportWithId + id + " has been deleted.");
     }
     
     public Airport createAirport(AirportDto airportDto) {

--- a/backend/src/main/java/com/rhyun/backend/airport/service/AirportService.java
+++ b/backend/src/main/java/com/rhyun/backend/airport/service/AirportService.java
@@ -17,6 +17,7 @@ public class AirportService {
 
     private final AirportRepository airportRepository;
     private final IdService idService;
+    private String airportWithId = "The airport with id ";
 
     public AirportService(AirportRepository airportRepository, IdService idService) {
         this.airportRepository = airportRepository;
@@ -42,12 +43,12 @@ public class AirportService {
 
     public Airport getAirportById(String id) {
         return airportRepository.findById(id)
-                .orElseThrow(() -> new AirportNotFoundException("The Airport with id " + id + " cannot be found."));
+                .orElseThrow(() -> new AirportNotFoundException(airportWithId + id + " cannot be found."));
     }
 
     public void deleteAirportById(String id) {
         airportRepository.deleteById(id);
-        System.out.println("The Airport with id "+ id + " has been deleted.");
+        System.out.println(airportWithId + id + " has been deleted.");
     }
     
     public Airport createAirport(AirportDto airportDto) {
@@ -64,7 +65,7 @@ public class AirportService {
 
     public Airport updateAirport(String id, AirportDto airportDto) {
         Airport airportToUpdate = airportRepository.findById(id)
-                .orElseThrow()
+                .orElseThrow(() -> new AirportNotFoundException(airportWithId + id + " cannot be found."))
                 .withName(airportDto.name())
                 .withIataCode(airportDto.iataCode())
                 .withGeoCode(airportDto.geoCode())

--- a/backend/src/main/java/com/rhyun/backend/flight/service/FlightService.java
+++ b/backend/src/main/java/com/rhyun/backend/flight/service/FlightService.java
@@ -4,6 +4,7 @@ import com.rhyun.backend.flight.dto.FlightDto;
 import com.rhyun.backend.flight.exception.FlightNotFountException;
 import com.rhyun.backend.flight.model.Flight;
 import com.rhyun.backend.flight.repository.FlightRepository;
+import com.rhyun.backend.globalservice.IdService;
 import org.springframework.stereotype.Service;
 
 import java.util.List;

--- a/backend/src/main/java/com/rhyun/backend/globalexception/ErrorMessage.java
+++ b/backend/src/main/java/com/rhyun/backend/globalexception/ErrorMessage.java
@@ -1,4 +1,4 @@
-package com.rhyun.backend.flight.exception;
+package com.rhyun.backend.globalexception;
 
 import java.util.Date;
 

--- a/backend/src/main/java/com/rhyun/backend/globalexception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/rhyun/backend/globalexception/GlobalExceptionHandler.java
@@ -1,6 +1,6 @@
-package com.rhyun.backend;
+package com.rhyun.backend.globalexception;
 
-import com.rhyun.backend.flight.exception.ErrorMessage;
+import com.rhyun.backend.airport.exception.AirportNotFoundException;
 import com.rhyun.backend.flight.exception.FlightNotFountException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -14,7 +14,17 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(FlightNotFountException.class)
     @ResponseStatus(HttpStatus.NOT_FOUND)
-    public ErrorMessage handleGlobalException(FlightNotFountException ex) {
+    public ErrorMessage handleFlightException(FlightNotFountException ex) {
+        return new ErrorMessage(
+                new Date(),
+                HttpStatus.NOT_FOUND.value(),
+                ex.getMessage()
+        );
+    }
+
+    @ExceptionHandler(AirportNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ErrorMessage handleAirportException(AirportNotFoundException ex) {
         return new ErrorMessage(
                 new Date(),
                 HttpStatus.NOT_FOUND.value(),

--- a/backend/src/main/java/com/rhyun/backend/globalservice/IdService.java
+++ b/backend/src/main/java/com/rhyun/backend/globalservice/IdService.java
@@ -1,4 +1,4 @@
-package com.rhyun.backend.flight.service;
+package com.rhyun.backend.globalservice;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/backend/src/test/java/com/rhyun/backend/airport/controller/AirportIntegrationTest.java
+++ b/backend/src/test/java/com/rhyun/backend/airport/controller/AirportIntegrationTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -172,5 +173,42 @@ class AirportIntegrationTest {
                 }
             """))
             .andExpect(jsonPath("$.timestamp").exists());
+    }
+
+    @Test
+    @DirtiesContext
+    void deleteAirportByIdTest_whenIdExists_thenDeleteAirportEntity() throws Exception {
+        // GIVEN
+        airportRepository.save(new Airport("123", "GDANSK", "GDN", new GeoCode(54, 18),
+                new AirportAddress("POLAND"), new AirportTimeZone("+02:00")));
+
+        mockMvc.perform(get("/api/airport"))
+            .andExpect(status().isOk())
+            .andExpect(content().json("""
+                [{
+                    "id": "123",
+                    "name": "GDANSK",
+                    "iataCode": "GDN",
+                    "geoCode": {
+                    "latitude": 54,
+                        "longitude": 18
+                    },
+                    "address": {
+                        "countryName": "POLAND"
+                    },
+                    "timeZone": {
+                        "offSet": "+02:00"
+                    }
+                }]
+            """));
+
+        // WHEN
+        mockMvc.perform(delete("/api/airport/123"))
+            // THEN
+            .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/airport"))
+            .andExpect(status().isOk())
+            .andExpect(content().json("[]"));
     }
 }

--- a/backend/src/test/java/com/rhyun/backend/airport/controller/AirportIntegrationTest.java
+++ b/backend/src/test/java/com/rhyun/backend/airport/controller/AirportIntegrationTest.java
@@ -13,8 +13,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -126,5 +125,52 @@ class AirportIntegrationTest {
                     }
                 ]
             """));
+    }
+
+    @Test
+    @DirtiesContext
+    void getAirportByIdTest_whenIdExists_thenReturnAirportEntity() throws Exception {
+        // GIVEN
+        airportRepository.save(new Airport("123", "GDANSK", "GDN", new GeoCode(54, 18),
+            new AirportAddress("POLAND"), new AirportTimeZone("+02:00"))
+        );
+
+        // WHEN
+        mockMvc.perform(get("/api/airport/123"))
+            // THEN
+            .andExpect(status().isOk())
+            .andExpect(content().json("""
+                {
+                    "id": "123",
+                    "name": "GDANSK",
+                    "iataCode": "GDN",
+                    "geoCode": {
+                    "latitude": 54,
+                        "longitude": 18
+                    },
+                    "address": {
+                        "countryName": "POLAND"
+                    },
+                    "timeZone": {
+                        "offSet": "+02:00"
+                    }
+                }
+            """));
+    }
+
+    @Test
+    @DirtiesContext
+    void getAirportByIdTest_whenIdDoesNotExist_thenThrow() throws Exception {
+        // GIVEN
+        // WHEN
+        mockMvc.perform(get("/api/airport/123"))
+            .andExpect(status().isNotFound())
+            .andExpect(content().json("""
+                {
+                    "status": 404,
+                    "message": "The Airport with id 123 cannot be found."
+                }
+            """))
+            .andExpect(jsonPath("$.timestamp").exists());
     }
 }

--- a/backend/src/test/java/com/rhyun/backend/airport/controller/AirportIntegrationTest.java
+++ b/backend/src/test/java/com/rhyun/backend/airport/controller/AirportIntegrationTest.java
@@ -1,6 +1,5 @@
 package com.rhyun.backend.airport.controller;
 
-import com.rhyun.backend.airport.dto.AirportDto;
 import com.rhyun.backend.airport.model.Airport;
 import com.rhyun.backend.airport.model.AirportAddress;
 import com.rhyun.backend.airport.model.AirportTimeZone;
@@ -170,7 +169,7 @@ class AirportIntegrationTest {
             .andExpect(content().json("""
                 {
                     "status": 404,
-                    "message": "The Airport with id 123 cannot be found."
+                    "message": "The airport with id 123 cannot be found."
                 }
             """))
             .andExpect(jsonPath("$.timestamp").exists());
@@ -245,5 +244,86 @@ class AirportIntegrationTest {
             .andExpect(jsonPath("$.geoCode.longitude").value(18))
             .andExpect(jsonPath("$.address.countryName").value("POLAND"))
             .andExpect(jsonPath("$.timeZone.offSet").value("+02:00"));
+    }
+
+    @Test
+    @DirtiesContext
+    void updateAirportTest_whenIdExists_thenUpdateAirportEntity() throws Exception {
+        // GIVEN
+        airportRepository.save(new Airport("123", "GDANSK", "GDN", new GeoCode(54, 18),
+                new AirportAddress("POLAND"), new AirportTimeZone("+02:00"))
+        );
+
+        // WHEN
+        mockMvc.perform(put("/api/airport/123")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("""
+                {
+                    "name": "GOTEBORG",
+                    "iataCode": "GOT",
+                    "geoCode": {
+                    "latitude": 57,
+                        "longitude": 12
+                    },
+                    "address": {
+                        "countryName": "SWEDEN"
+                    },
+                    "timeZone": {
+                        "offSet": "+02:00"
+                    }
+                }
+            """))
+            // THEN
+            .andExpect(status().isOk())
+            .andExpect(content().json("""
+                {
+                    "id": "123",
+                    "name": "GOTEBORG",
+                    "iataCode": "GOT",
+                    "geoCode": {
+                    "latitude": 57,
+                        "longitude": 12
+                    },
+                    "address": {
+                        "countryName": "SWEDEN"
+                    },
+                    "timeZone": {
+                        "offSet": "+02:00"
+                    }
+                }
+            """));
+    }
+
+    @Test
+    @DirtiesContext
+    void updateAirportTest_whenIdDoesNotExist_thenThrow() throws Exception {
+        // GIVEN
+        // WHEN
+        mockMvc.perform(put("/api/airport/123")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("""
+                {
+                    "name": "GOTEBORG",
+                    "iataCode": "GOT",
+                    "geoCode": {
+                    "latitude": 57,
+                        "longitude": 12
+                    },
+                    "address": {
+                        "countryName": "SWEDEN"
+                    },
+                    "timeZone": {
+                        "offSet": "+02:00"
+                    }
+                }
+            """))
+            // THEN
+            .andExpect(status().isNotFound())
+            .andExpect(content().json("""
+                {
+                    "status": 404,
+                    "message": "The airport with id 123 cannot be found."
+                }
+            """));
     }
 }

--- a/backend/src/test/java/com/rhyun/backend/airport/controller/AirportIntegrationTest.java
+++ b/backend/src/test/java/com/rhyun/backend/airport/controller/AirportIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.rhyun.backend.airport.controller;
 
+import com.rhyun.backend.airport.dto.AirportDto;
 import com.rhyun.backend.airport.model.Airport;
 import com.rhyun.backend.airport.model.AirportAddress;
 import com.rhyun.backend.airport.model.AirportTimeZone;
@@ -9,11 +10,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest
@@ -190,7 +191,7 @@ class AirportIntegrationTest {
                     "name": "GDANSK",
                     "iataCode": "GDN",
                     "geoCode": {
-                    "latitude": 54,
+                        "latitude": 54,
                         "longitude": 18
                     },
                     "address": {
@@ -210,5 +211,39 @@ class AirportIntegrationTest {
         mockMvc.perform(get("/api/airport"))
             .andExpect(status().isOk())
             .andExpect(content().json("[]"));
+    }
+
+    @Test
+    @DirtiesContext
+    void createAirportTest_whenPayloadIsCorrect_thenSaveAirportEntity() throws Exception {
+        // GIVEN
+        // WHEN
+        mockMvc.perform(post("/api/airport")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("""
+                {
+                    "name": "GDANSK",
+                    "iataCode": "GDN",
+                    "geoCode": {
+                        "latitude": 54,
+                        "longitude": 18
+                    },
+                    "address": {
+                        "countryName": "POLAND"
+                    },
+                    "timeZone": {
+                        "offSet": "+02:00"
+                    }
+                }
+            """))
+            // THEN
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").exists())
+            .andExpect(jsonPath("$.name").value("GDANSK"))
+            .andExpect(jsonPath("$.iataCode").value("GDN"))
+            .andExpect(jsonPath("$.geoCode.latitude").value(54))
+            .andExpect(jsonPath("$.geoCode.longitude").value(18))
+            .andExpect(jsonPath("$.address.countryName").value("POLAND"))
+            .andExpect(jsonPath("$.timeZone.offSet").value("+02:00"));
     }
 }

--- a/backend/src/test/java/com/rhyun/backend/airport/service/AirportServiceTest.java
+++ b/backend/src/test/java/com/rhyun/backend/airport/service/AirportServiceTest.java
@@ -118,4 +118,16 @@ class AirportServiceTest {
         assertThrows(AirportNotFoundException.class, () -> airportService.getAirportById(id));
         verify(airportRepository, times(1)).findById(id);
     }
+
+    @Test
+    void deleteAirportByIdTest_whenIdExists_thenDeleteFlightEntity() {
+        // GIVEN
+        String id = "123";
+        doNothing().when(airportRepository).deleteById(id);
+
+        // WHEN
+        // THEN
+        airportService.deleteAirportById(id);
+        verify(airportRepository, times(1)).deleteById(id);
+    }
 }

--- a/backend/src/test/java/com/rhyun/backend/airport/service/AirportServiceTest.java
+++ b/backend/src/test/java/com/rhyun/backend/airport/service/AirportServiceTest.java
@@ -1,6 +1,7 @@
 package com.rhyun.backend.airport.service;
 
 import com.rhyun.backend.airport.dto.GetAirportDto;
+import com.rhyun.backend.airport.exception.AirportNotFoundException;
 import com.rhyun.backend.airport.model.Airport;
 import com.rhyun.backend.airport.model.AirportAddress;
 import com.rhyun.backend.airport.model.AirportTimeZone;
@@ -10,9 +11,11 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 class AirportServiceTest {
@@ -85,5 +88,34 @@ class AirportServiceTest {
 
         assertEquals(expected, actual);
         verify(airportRepository, times(1)).findAll();
+    }
+
+    @Test
+    void getAirportByIdTest_whenIdExists_thenReturnAnAirline() {
+        // GIVEN
+        String id = "123";
+        when(airportRepository.findById(id)).thenReturn(Optional.of(airport1));
+
+        // WHEN
+        Airport actual = airportService.getAirportById(id);
+
+        // THEN
+        Airport expected = new Airport("123", "GDANSK", "GDN", new GeoCode(54, 18),
+                new AirportAddress("POLAND"), new AirportTimeZone("+02:00"));
+
+        assertEquals(expected, actual);
+        verify(airportRepository, times(1)).findById(id);
+    }
+
+    @Test
+    void getAirportByIdTest_whenIdDoesNotExist_thenThrow() {
+        // GIVEN
+        String id = "135";
+        when(airportRepository.findById(id)).thenReturn(Optional.empty());
+
+        // WHEN
+        // THEN
+        assertThrows(AirportNotFoundException.class, () -> airportService.getAirportById(id));
+        verify(airportRepository, times(1)).findById(id);
     }
 }

--- a/backend/src/test/java/com/rhyun/backend/airport/service/AirportServiceTest.java
+++ b/backend/src/test/java/com/rhyun/backend/airport/service/AirportServiceTest.java
@@ -179,4 +179,21 @@ class AirportServiceTest {
         verify(airportRepository, times(1)).findById("1");
         verify(airportRepository, times(1)).save(updated);
     }
+
+    @Test
+    void updateAirportTest_whenIdDoesNotExist_thenThrow() {
+        // GIVEN
+        AirportDto updateDto = new AirportDto( "GOTEBORG", "GOT", new GeoCode(57, 12),
+                new AirportAddress("SWEDEN"), new AirportTimeZone("+02:00"));
+        Airport updated = new Airport("1", updateDto.name(), updateDto.iataCode(), updateDto.geoCode(),
+                updateDto.address(), updateDto.timeZone());
+
+        when(airportRepository.findById("1")).thenReturn(Optional.empty());
+
+        // WHEN
+        // THEN
+        assertThrows(AirportNotFoundException.class, () -> airportService.updateAirport("1", updateDto));
+        verify(airportRepository, times(1)).findById("1");
+        verify(airportRepository, never()).save(updated);
+    }
 }

--- a/backend/src/test/java/com/rhyun/backend/airport/service/AirportServiceTest.java
+++ b/backend/src/test/java/com/rhyun/backend/airport/service/AirportServiceTest.java
@@ -16,8 +16,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 class AirportServiceTest {
@@ -154,5 +153,30 @@ class AirportServiceTest {
         assertEquals(expected, actual);
         verify(airportRepository, times(1)).save(airportToSave);
         verify(idService, times(1)).randomId();
+    }
+
+    @Test
+    void updateAirportTest_whenIdExistsAndPayloadIsCorrect_thenUpdateAirportEntity() {
+        // GIVEN
+        Airport original = new Airport("1", "GDANSK", "GDN", new GeoCode(54, 18),
+                new AirportAddress("POLAND"), new AirportTimeZone("+02:00"));
+
+        AirportDto updateDto = new AirportDto( "GOTEBORG", "GOT", new GeoCode(57, 12),
+                new AirportAddress("SWEDEN"), new AirportTimeZone("+02:00"));
+
+        Airport updated = new Airport("1", updateDto.name(), updateDto.iataCode(), updateDto.geoCode(),
+                updateDto.address(), updateDto.timeZone());
+
+        when(airportRepository.findById("1")).thenReturn(Optional.of(original));
+        when(airportRepository.save(updated)).thenReturn(updated);
+
+        // WHEN
+        Airport actual = airportService.updateAirport("1", updateDto);
+
+        // THEN
+        assertNotNull(actual);
+        assertEquals(updated, actual);
+        verify(airportRepository, times(1)).findById("1");
+        verify(airportRepository, times(1)).save(updated);
     }
 }

--- a/backend/src/test/java/com/rhyun/backend/flight/service/FlightServiceTest.java
+++ b/backend/src/test/java/com/rhyun/backend/flight/service/FlightServiceTest.java
@@ -6,6 +6,7 @@ import com.rhyun.backend.flight.model.Airline;
 import com.rhyun.backend.flight.model.Flight;
 import com.rhyun.backend.flight.model.FlightStatus;
 import com.rhyun.backend.flight.repository.FlightRepository;
+import com.rhyun.backend.globalservice.IdService;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;


### PR DESCRIPTION
Add endpoints for the following operations to Airport Entity (only in Backend)
- findById
- delete
- save
- update

In addition, unit and integration tests are included.